### PR TITLE
Fix missing dependency in PyInstaller build

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,7 +2,8 @@
 @echo off
 REM Costruisce l'eseguibile standalone con PyInstaller
 pip install --upgrade pip
-pip install pyinstaller PyYAML
+pip install pyinstaller
+pip install -r requirements.txt
 cd src
 pyinstaller --onefile --noconsole --name "FileAIOrganizer" main.py
 echo Build completata. Troverai l'eseguibile in dist\FileAIOrganizer.exe


### PR DESCRIPTION
## Summary
- install project dependencies when building for Windows

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68769a436068832e96de3c100784d374